### PR TITLE
Fix - DisplayName not showing on player head

### DIFF
--- a/src/main/java/me/pulsi_/bankplus/guis/ItemUtils.java
+++ b/src/main/java/me/pulsi_/bankplus/guis/ItemUtils.java
@@ -123,9 +123,11 @@ public class ItemUtils {
         for (String lines : c.getStringList("Lore")) lore.add(ChatUtils.color(lines));
 
         if (BankPlus.getInstance().isPlaceholderAPIHooked()) {
-            if (PlaceholderAPI.containsPlaceholders(displayName))
-                meta.setDisplayName(PlaceholderAPI.setPlaceholders(p, displayName));
+            meta.setDisplayName(PlaceholderAPI.setPlaceholders(p, displayName));
             meta.setLore(PlaceholderAPI.setPlaceholders(p, lore));
+        } else {
+            meta.setDisplayName(displayName);
+            meta.setLore(lore);
         }
 
         i.setItemMeta(meta);


### PR DESCRIPTION
The displayName in GUI was not showing when you change the material to HEAD in config.yml
Also, I made the displayName and lore show without placeholderAPI(Just it will not parse the placeholders if papi not installed)

Thank you,
DTech - Creator of RagnaRock Server (play.ragnarockmc.in)