### PR TITLE
Added Command /bankopen

### DIFF
--- a/src/main/java/me/pulsi_/bankplus/bankGuis/BanksHolder.java
+++ b/src/main/java/me/pulsi_/bankplus/bankGuis/BanksHolder.java
@@ -3,23 +3,23 @@ package me.pulsi_.bankplus.bankGuis;
 import me.clip.placeholderapi.PlaceholderAPI;
 import me.pulsi_.bankplus.BankPlus;
 import me.pulsi_.bankplus.account.BankPlusPlayer;
-import me.pulsi_.bankplus.utils.BPMessages;
-import me.pulsi_.bankplus.utils.BPChat;
-import me.pulsi_.bankplus.utils.BPItems;
-import me.pulsi_.bankplus.utils.BPMethods;
+import me.pulsi_.bankplus.utils.*;
 import me.pulsi_.bankplus.values.Values;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.scheduler.BukkitTask;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 
 public class BanksHolder implements InventoryHolder {
 
@@ -63,6 +63,7 @@ public class BanksHolder implements InventoryHolder {
         p.openInventory(bank);
     }
 
+
     private void placeHeads(Inventory bank, Player p, String identifier) {
         ConfigurationSection items = new BanksManager(identifier).getItems();
         if (items == null) return;
@@ -72,12 +73,37 @@ public class BanksHolder implements InventoryHolder {
             if (itemValues == null) continue;
 
             String material = itemValues.getString("Material");
-            if (material == null || !material.startsWith("HEAD")) continue;
+            if (material == null) continue;
 
-            try {
-                bank.setItem(itemValues.getInt("Slot") - 1, BPItems.getHead(material, p));
-            } catch (ArrayIndexOutOfBoundsException e) {
-                bank.addItem(BPItems.getHead(material, p));
+            if (material.startsWith("HEAD")){
+                try {
+                    bank.setItem(itemValues.getInt("Slot") - 1, BPItems.getHead(material, p));
+                } catch (ArrayIndexOutOfBoundsException e) {
+                    bank.addItem(BPItems.getHead(material, p));
+                }
+            }
+
+            if(material.startsWith("PLAYER_HEAD")){
+                String texture = itemValues.getString("Texture");
+                int customModelData = itemValues.getInt("CustomModelData");
+                ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+                if(texture != null) {
+                    texture = PlaceholderAPI.setPlaceholders(p, texture);
+                    UUID hashAsId = new UUID(texture.hashCode(), texture.hashCode());
+                    head = Bukkit.getUnsafe().modifyItemStack(head, "{SkullOwner:{Id:\"" + hashAsId + "\",Properties:{textures:[{Value:\"" + texture + "\"}]}}}");
+                    if(customModelData > 0){
+                        ItemMeta headMeta = head.getItemMeta();
+                        headMeta.setCustomModelData(customModelData);
+                        head.setItemMeta(headMeta);
+                    }
+                }
+
+                try{
+                    bank.setItem(itemValues.getInt("Slot")-1, head);
+                }catch (ArrayIndexOutOfBoundsException e){
+                    bank.addItem(head);
+                }
+
             }
         }
     }

--- a/src/main/java/me/pulsi_/bankplus/bankGuis/BanksManager.java
+++ b/src/main/java/me/pulsi_/bankplus/bankGuis/BanksManager.java
@@ -126,6 +126,7 @@ public class BanksManager {
                             BPLogger.warn("Cannot set custom model data to the item: \"" + displayname + "\"&e. Custom model data is only available on 1.14.4+ servers!");
                         }
                     }
+
                     guiItem.setItemMeta(meta);
 
                     try {

--- a/src/main/java/me/pulsi_/bankplus/commands/ConsoleBankOpen.java
+++ b/src/main/java/me/pulsi_/bankplus/commands/ConsoleBankOpen.java
@@ -27,6 +27,7 @@ public class ConsoleBankOpen implements CommandExecutor {
                 }else{
                     BanksHolder banksHolder = new BanksHolder();
                     banksHolder.openBank(targetPlayer);
+                    return true;
                 }
             }
         }

--- a/src/main/java/me/pulsi_/bankplus/commands/ConsoleBankOpen.java
+++ b/src/main/java/me/pulsi_/bankplus/commands/ConsoleBankOpen.java
@@ -1,0 +1,35 @@
+package me.pulsi_.bankplus.commands;
+
+import me.pulsi_.bankplus.bankGuis.BanksHolder;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class ConsoleBankOpen implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if(sender instanceof ConsoleCommandSender){
+            if(args.length == 0){
+                sender.sendMessage("[BankPlus]Error! Use /bankopen <player>");
+                return false;
+            }
+            if(args.length == 1){
+                String target = args[0];
+                Player targetPlayer = Bukkit.getPlayerExact(target);
+                if(targetPlayer == null){
+                    sender.sendMessage("[BankPlus]Error! Target not found");
+                    return false;
+                }else{
+                    BanksHolder banksHolder = new BanksHolder();
+                    banksHolder.openBank(targetPlayer);
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/me/pulsi_/bankplus/managers/DataManager.java
+++ b/src/main/java/me/pulsi_/bankplus/managers/DataManager.java
@@ -4,6 +4,7 @@ import me.pulsi_.bankplus.BankPlus;
 import me.pulsi_.bankplus.account.BankPlusPlayerFiles;
 import me.pulsi_.bankplus.bankGuis.BanksManager;
 import me.pulsi_.bankplus.commands.BankTopCmd;
+import me.pulsi_.bankplus.commands.ConsoleBankOpen;
 import me.pulsi_.bankplus.commands.MainCmd;
 import me.pulsi_.bankplus.external.UpdateChecker;
 import me.pulsi_.bankplus.external.bStats;
@@ -147,5 +148,6 @@ public class DataManager {
         plugin.getCommand("bankplus").setExecutor(new MainCmd());
         plugin.getCommand("bankplus").setTabCompleter(new MainCmd());
         plugin.getCommand("banktop").setExecutor(new BankTopCmd());
+        plugin.getCommand("bankopen").setExecutor(new ConsoleBankOpen());
     }
 }

--- a/src/main/java/me/pulsi_/bankplus/utils/BPItems.java
+++ b/src/main/java/me/pulsi_/bankplus/utils/BPItems.java
@@ -1,5 +1,6 @@
 package me.pulsi_.bankplus.utils;
 
+import me.clip.placeholderapi.PlaceholderAPI;
 import me.pulsi_.bankplus.bankGuis.BankGui;
 import org.bukkit.Material;
 import org.bukkit.SkullType;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,6 +14,7 @@ description: The best bank plugin on Spigot!
 commands:
   bankplus:
     aliases: [bankp, bank, bp]
-
+  bankopen:
+    usage: /bankopen player - Open Bank to Player from Console
   banktop:
     aliases: [btop]


### PR DESCRIPTION
This command is runned only in Console.

With this command, players can use it adding to NPCs or ArmorStand that when clicked open the BankGUI.

Why? There may be servers, like mine, where owners don't want to give players the command /bank