### PR TITLE
fix NPE while plugin enabled by PlugMan

### DIFF
--- a/src/main/java/me/pulsi_/bankplus/BankPlus.java
+++ b/src/main/java/me/pulsi_/bankplus/BankPlus.java
@@ -101,6 +101,14 @@ public final class BankPlus extends JavaPlugin {
         if (Values.CONFIG.isUpdateCheckerEnabled()) Bukkit.getScheduler().runTaskTimerAsynchronously(this, () -> isUpdated = isPluginUpdated(), 0, (8 * 1200) * 60);
         wasOnSingleEconomy = !Values.MULTIPLE_BANKS.isMultipleBanksModuleEnabled();
 
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            BankPlusPlayerFiles files = new BankPlusPlayerFiles(p);
+            files.registerPlayer();
+
+            BankPlusPlayer player = new BankPlusPlayer(p, files.getPlayerFile(), files.getPlayerConfig());
+            BankPlus.INSTANCE.getPlayerRegistry().put(p, player);
+        }
+
         BPVersions.moveBankFileToBanksFolder();
         BPVersions.changePlayerStoragePosition();
         BPVersions.updateBankFileActions();

--- a/src/main/java/me/pulsi_/bankplus/account/PlayerRegistry.java
+++ b/src/main/java/me/pulsi_/bankplus/account/PlayerRegistry.java
@@ -14,13 +14,6 @@ public class PlayerRegistry {
     }
 
     public BankPlusPlayer get(Player p) {
-        if (!contains(p)) {
-            BankPlusPlayerFiles files = new BankPlusPlayerFiles(p);
-            files.registerPlayer();
-            BankPlusPlayer player = new BankPlusPlayer(p, files.getPlayerFile(), files.getPlayerConfig());
-            put(p, player);
-            return player;
-        }
         return players.get(p.getUniqueId());
     }
 

--- a/src/main/java/me/pulsi_/bankplus/account/PlayerRegistry.java
+++ b/src/main/java/me/pulsi_/bankplus/account/PlayerRegistry.java
@@ -14,6 +14,13 @@ public class PlayerRegistry {
     }
 
     public BankPlusPlayer get(Player p) {
+        if (!contains(p)) {
+            BankPlusPlayerFiles files = new BankPlusPlayerFiles(p);
+            files.registerPlayer();
+            BankPlusPlayer player = new BankPlusPlayer(p, files.getPlayerFile(), files.getPlayerConfig());
+            put(p, player);
+            return player;
+        }
         return players.get(p.getUniqueId());
     }
 

--- a/src/main/java/me/pulsi_/bankplus/listeners/PlayerQuitListener.java
+++ b/src/main/java/me/pulsi_/bankplus/listeners/PlayerQuitListener.java
@@ -28,7 +28,7 @@ public class PlayerQuitListener implements Listener {
             economyManager.unloadBankBalance();
         }
         BankPlusPlayer player = BankPlus.INSTANCE.getPlayerRegistry().remove(p);
-
+        if (player == null) return;
         Bank openedBank = player.getOpenedBank();
         if (openedBank != null) {
             BukkitTask task = openedBank.getInventoryUpdateTask();


### PR DESCRIPTION
As you see. If we load BankPlus by some *PlugMan*-like plugin manager, players join in server before the plugin load. Your registry in `PlayerJoinListener` have no effect until they rejoin server. And it caused NPE while open bank GUI.
```
[00:03:43] [Server thread/INFO]: MrXiaoM issued server command: /bank
[00:03:43] [Server thread/ERROR]: null
org.bukkit.command.CommandException: Unhandled exception executing command 'bank' in plugin BankPlus v5.7
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:47) ~[patched_1.16.5.jar:git-Purpur-1171]
	at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:172) ~[patched_1.16.5.jar:git-Purpur-1171]
	at org.bukkit.craftbukkit.v1_16_R3.CraftServer.dispatchCommand(CraftServer.java:826) ~[patched_1.16.5.jar:git-Purpur-1171]
	at net.minecraft.server.v1_16_R3.PlayerConnection.handleCommand(PlayerConnection.java:2315) ~[patched_1.16.5.jar:git-Purpur-1171]
	at net.minecraft.server.v1_16_R3.PlayerConnection.c(PlayerConnection.java:2130) ~[patched_1.16.5.jar:git-Purpur-1171]
	at net.minecraft.server.v1_16_R3.PlayerConnection.a(PlayerConnection.java:2083) ~[patched_1.16.5.jar:git-Purpur-1171]
	at net.minecraft.server.v1_16_R3.PacketPlayInChat.a(PacketPlayInChat.java:49) ~[patched_1.16.5.jar:git-Purpur-1171]
	at net.minecraft.server.v1_16_R3.PacketPlayInChat.a(PacketPlayInChat.java:7) ~[patched_1.16.5.jar:git-Purpur-1171]
	at net.minecraft.server.v1_16_R3.PlayerConnectionUtils.lambda$ensureMainThread$1(PlayerConnectionUtils.java:55) ~[patched_1.16.5.jar:git-Purpur-1171]
	at net.minecraft.server.v1_16_R3.TickTask.run(SourceFile:18) ~[patched_1.16.5.jar:git-Purpur-1171]
	at net.minecraft.server.v1_16_R3.IAsyncTaskHandler.executeTask(IAsyncTaskHandler.java:136) ~[patched_1.16.5.jar:git-Purpur-1171]
	at net.minecraft.server.v1_16_R3.IAsyncTaskHandlerReentrant.executeTask(SourceFile:23) ~[patched_1.16.5.jar:git-Purpur-1171]
	at net.minecraft.server.v1_16_R3.IAsyncTaskHandler.executeNext(IAsyncTaskHandler.java:109) ~[patched_1.16.5.jar:git-Purpur-1171]
	at net.minecraft.server.v1_16_R3.MinecraftServer.bb(MinecraftServer.java:1339) ~[patched_1.16.5.jar:git-Purpur-1171]
	at net.minecraft.server.v1_16_R3.MinecraftServer.executeNext(MinecraftServer.java:1332) ~[patched_1.16.5.jar:git-Purpur-1171]
	at net.minecraft.server.v1_16_R3.IAsyncTaskHandler.awaitTasks(IAsyncTaskHandler.java:119) ~[patched_1.16.5.jar:git-Purpur-1171]
	at net.minecraft.server.v1_16_R3.MinecraftServer.a(MinecraftServer.java:1407) ~[patched_1.16.5.jar:git-Purpur-1171]
	at net.minecraft.server.v1_16_R3.MinecraftServer.w(MinecraftServer.java:1142) ~[patched_1.16.5.jar:git-Purpur-1171]
	at net.minecraft.server.v1_16_R3.MinecraftServer.lambda$a$0(MinecraftServer.java:293) ~[patched_1.16.5.jar:git-Purpur-1171]
	at java.lang.Thread.run(Thread.java:834) [?:?]
Caused by: java.lang.NullPointerException
	at me.pulsi_.bankplus.bankGuis.BanksHolder.openBank(BanksHolder.java:49) ~[?:?]
	at me.pulsi_.bankplus.bankGuis.BanksHolder.openBank(BanksHolder.java:27) ~[?:?]
	at me.pulsi_.bankplus.commands.cmdProcessor.SingleCmdProcessor.processCmd(SingleCmdProcessor.java:38) ~[?:?]
	at me.pulsi_.bankplus.commands.MainCmd.onCommand(MainCmd.java:123) ~[?:?]
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[patched_1.16.5.jar:git-Purpur-1171]
	... 19 more
```
