### PR TITLE
fix: remove correct amount of required items for bank upgrade

### DIFF
--- a/src/main/java/me/pulsi_/bankplus/bankSystem/BankUtils.java
+++ b/src/main/java/me/pulsi_/bankplus/bankSystem/BankUtils.java
@@ -515,7 +515,7 @@ public class BankUtils {
         }
 
         if (isRemovingRequiredItems(bank, nextLevel) && canRemoveSafely)
-            for (Bank.RequiredItem requiredItem : requiredItems) p.getInventory().removeItem(requiredItem.item);
+            for (Bank.RequiredItem requiredItem : requiredItems) p.getInventory().removeItem(new ItemStack(requiredItem.item.getType(), requiredItem.amount));
 
         setLevel(bank, p, nextLevel);
         BPMessages.sendIdentifier(p, "Bank-Upgraded");

--- a/src/main/java/me/pulsi_/bankplus/bankSystem/BankUtils.java
+++ b/src/main/java/me/pulsi_/bankplus/bankSystem/BankUtils.java
@@ -18,6 +18,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
@@ -514,8 +515,16 @@ public class BankUtils {
             vaultEconomy.withdrawPlayer(p, cost.doubleValue());
         }
 
-        if (isRemovingRequiredItems(bank, nextLevel) && canRemoveSafely)
-            for (Bank.RequiredItem requiredItem : requiredItems) p.getInventory().removeItem(new ItemStack(requiredItem.item.getType(), requiredItem.amount));
+        if (isRemovingRequiredItems(bank, nextLevel) && canRemoveSafely) {
+            PlayerInventory inventory = p.getInventory();
+
+            for (Bank.RequiredItem requiredItem : requiredItems) {
+                ItemStack item = requiredItem.item.clone();
+                item.setAmount(requiredItem.amount);
+
+                inventory.removeItem(item);
+            }
+        }
 
         setLevel(bank, p, nextLevel);
         BPMessages.sendIdentifier(p, "Bank-Upgraded");

--- a/src/main/java/me/pulsi_/bankplus/commands/list/GiveRequiredItemsCmd.java
+++ b/src/main/java/me/pulsi_/bankplus/commands/list/GiveRequiredItemsCmd.java
@@ -110,7 +110,7 @@ public class GiveRequiredItemsCmd extends BPCommand {
         return new BPCmdExecution() {
             @Override
             public void execute() {
-                for (Bank.RequiredItem requiredItem : givenItems) target.getInventory().addItem(requiredItem.item);
+                for (Bank.RequiredItem requiredItem : givenItems) target.getInventory().addItem(new ItemStack(requiredItem.item.getType(), requiredItem.amount));
             }
         };
     }

--- a/src/main/java/me/pulsi_/bankplus/commands/list/GiveRequiredItemsCmd.java
+++ b/src/main/java/me/pulsi_/bankplus/commands/list/GiveRequiredItemsCmd.java
@@ -13,6 +13,8 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
@@ -110,7 +112,20 @@ public class GiveRequiredItemsCmd extends BPCommand {
         return new BPCmdExecution() {
             @Override
             public void execute() {
-                for (Bank.RequiredItem requiredItem : givenItems) target.getInventory().addItem(new ItemStack(requiredItem.item.getType(), requiredItem.amount));
+                PlayerInventory inventory = target.getInventory();
+
+                for (Bank.RequiredItem requiredItem : givenItems) {
+                    ItemStack item = requiredItem.item.clone();
+                    item.setAmount(requiredItem.amount);
+
+                    HashMap<Integer, ItemStack> leftover = inventory.addItem(item);
+
+                    if (!leftover.isEmpty()) {
+                        leftover.values().forEach(stack ->
+                                target.getWorld().dropItemNaturally(target.getLocation(), stack)
+                        );
+                    }
+                }
             }
         };
     }


### PR DESCRIPTION
Resolves an issue introduced by changes made in this commit https://github.com/Pulsih/BankPlus/commit/536f9a38d3b828b3266c42c27985b61f7b8ed937. 
> An upgrade requires X items, but only consumes one of the item

