### PR TITLE
fix: if user is not loaded do not return default values

### DIFF
--- a/src/main/java/me/pulsi_/bankplus/economy/BPEconomy.java
+++ b/src/main/java/me/pulsi_/bankplus/economy/BPEconomy.java
@@ -443,7 +443,6 @@ public class BPEconomy {
      * @param p The player.
      */
     public BigDecimal getDebt(OfflinePlayer p) {
-        if (!isPlayerLoaded(p)) return BigDecimal.ZERO;
         return getHolder(p).debt;
     }
 
@@ -466,7 +465,6 @@ public class BPEconomy {
      * @return The current bank level.
      */
     public int getBankLevel(OfflinePlayer p) {
-        if (!isPlayerLoaded(p)) return 1;
         return getHolder(p).bankLevel;
     }
 


### PR DESCRIPTION
Resolves an issue introduced by changes made in this commit https://github.com/Pulsih/BankPlus/commit/11b40c76006e04416d9640e0fec6f7261bb692ba.

Offline interest calculations rely on the player’s bank level, but if the player is not loaded, it defaults to level 1. This leads to incorrect interest rates being applied and can overwrite the correct bank capacity.